### PR TITLE
Allow individual editing of components after pasting (issue 6)

### DIFF
--- a/cartridges/sfcc_super_pd/cartridge/experience/components/layouts/spdLayout/spdLayout.js
+++ b/cartridges/sfcc_super_pd/cartridge/experience/components/layouts/spdLayout/spdLayout.js
@@ -30,7 +30,7 @@ module.exports.render = function (context, modelIn) {
     var cssSelectorByEditor = 'layout-' + layoutEditor.key;
     var cssSelectorForIndividualRegion = 'layout-' + componentId;
 
-    model.cssSelector = classNameForIndividualRegion;
+    model.cssSelector = cssSelectorForIndividualRegion;
     model.regionsCss = layoutEditor.regionsRawCss;
     model.containerCss = layoutEditor.containerRawCss.replace(cssSelectorByEditor, cssSelectorForIndividualRegion);
     

--- a/cartridges/sfcc_super_pd/cartridge/experience/components/layouts/spdLayout/spdLayout.js
+++ b/cartridges/sfcc_super_pd/cartridge/experience/components/layouts/spdLayout/spdLayout.js
@@ -25,11 +25,15 @@ module.exports.render = function (context, modelIn) {
 
     var component = context.component;
     var regions = PageRenderHelper.getRegionModelRegistry(component);
+    var componentId = context.component.ID;
 
-    model.cssSelector = 'layout-' + layoutEditor.key;
+    var cssSelectorByEditor = 'layout-' + layoutEditor.key;
+    var cssSelectorForIndividualRegion = 'layout-' + componentId;
+
+    model.cssSelector = classNameForIndividualRegion;
     model.regionsCss = layoutEditor.regionsRawCss;
-    model.containerCss = layoutEditor.containerRawCss;
-
+    model.containerCss = layoutEditor.containerRawCss.replace(cssSelectorByEditor, cssSelectorForIndividualRegion);
+    
     model.regions = regions;
     return new Template('experience/components/layouts/spdLayout').render(model).text;
 };

--- a/cartridges/sfcc_super_pd/cartridge/experience/components/layouts/spdRegion/spdRegion.js
+++ b/cartridges/sfcc_super_pd/cartridge/experience/components/layouts/spdRegion/spdRegion.js
@@ -25,7 +25,7 @@ module.exports.render = function (context, modelIn) {
     var cssSelectorForIndividualRegion = 'region-' + componentId;
     
     if (regionEditor) {
-        regionClassName += ' ' + classNameForIndividualRegion;
+        regionClassName += ' ' + cssSelectorForIndividualRegion;
     }
 
     var componentRenderSettings = context.componentRenderSettings;

--- a/cartridges/sfcc_super_pd/cartridge/experience/components/layouts/spdRegion/spdRegion.js
+++ b/cartridges/sfcc_super_pd/cartridge/experience/components/layouts/spdRegion/spdRegion.js
@@ -18,11 +18,14 @@ module.exports.render = function (context, modelIn) {
     var content = context.content;
     var component = context.component;
     var regionEditor = content.regionEditor.value;
-
+    var componentId = component.ID;
     var regionClassName = 'spdlayout-region';
-
+    
+    var cssSelectorByEditor = 'region-' + regionEditor.key;
+    var cssSelectorForIndividualRegion = 'region-' + componentId;
+    
     if (regionEditor) {
-        regionClassName += ' region-' + regionEditor.key;
+        regionClassName += ' ' + classNameForIndividualRegion;
     }
 
     var componentRenderSettings = context.componentRenderSettings;
@@ -30,7 +33,7 @@ module.exports.render = function (context, modelIn) {
         class: regionClassName,
     });
 
-    model.regionsCss = regionEditor ? regionEditor.regionRawCss : '';
+    model.regionsCss = regionEditor ? regionEditor.regionRawCss.replace(cssSelectorByEditor,cssSelectorForIndividualRegion) : '';
 
     model.regions = PageRenderHelper.getRegionModelRegistry(component);
 


### PR DESCRIPTION
Issue #6 The approach is a little hacky, let me know if this is an OK approach or how we can achieve the same more cleanly. 

The editor doesn't know which component it targets - so the important bit is that the css selector is generated per component not per layout